### PR TITLE
Add conda installation information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,10 @@ graphtools is available on `pip`. Install by running the following in a terminal
 Or, to install the latest version from github::
 
         pip install --user git+git://github.com/KrishnaswamyLab/graphtools.git
+        
+Alternatively, graphtools can be installed using [Conda](https://conda.io/docs/) (most easily obtained via the [Miniconda Python distribution](https://conda.io/miniconda.html)):
+
+        conda install -c conda-forge graphtools
 
 Usage example
 -------------


### PR DESCRIPTION
Hi,


graphtools is now available via conda and [conda-forge channel](https://anaconda.org/conda-forge/graphtools). With this PR, I added the information for installation via conda.

Bérénice