### PR TITLE
include LICENSE file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
The GPL requires redistributions to include your `LICENSE` file, but it's currently not included in your `tar.gz` or wheel files (making life harder for packagers). The `MANIFEST.in` file makes it go in `tar.gz`s, and the `setup.cfg` is for wheels.